### PR TITLE
Add DAP process check and fix intepreter scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "ansibug" extension will be documented in this file.
 
+## [0.1.1]
+
+- Add basic check to verify `ansibug` can be spawned as the DAP process
+- Use the default scope for `ansibug.interpreterPath`
+
 ## [0.1.0]
 
 - Initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ansibug",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "jborean",
   "engines": {
     "vscode": "^1.63.0"
@@ -44,7 +44,6 @@
         "title": "Ansibug",
         "properties": {
           "ansibug.interpreterPath": {
-            "scope": "machine-overridable",
             "type": "string",
             "default": null,
             "markdownDescription": "Path to the Python interpreter executable. Particularly important if you are using a Python virtual environment. Leave blank to use Python from PATH.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,8 +15,8 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.debug.registerDebugAdapterDescriptorFactory(
             "ansible",
             {
-                createDebugAdapterDescriptor: () => {
-                    return createAnsibleDebugAdapter();
+                createDebugAdapterDescriptor: async () => {
+                    return await createAnsibleDebugAdapter();
                 },
             }
         )


### PR DESCRIPTION
Add a basic check to see if we can spawn a Python process that starts the ansibug DAP process. This will error on a failure rather than just stop the debug mode on the client. Also sets the ansibug.interpreterPath option to use the default scope option.