### PR TITLE
Fix up Python interpreter selection logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 All notable changes to the "ansibug" extension will be documented in this file.
 
-## [0.1.1]
+## 0.1.2 - TBD
 
-- Add basic check to verify `ansibug` can be spawned as the DAP process
-- Use the default scope for `ansibug.interpreterPath`
++ Add extra logic for finding the Python interpreter in the PATH or from the settings
 
-## [0.1.0]
+## 0.1.1 - 2024-05-03
 
-- Initial release
++ Add basic check to verify `ansibug` can be spawned as the DAP process
++ Use the default scope for `ansibug.interpreterPath`
+
+## 0.1.0 - 2024-05-02
+
++ Initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ansibug",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "jborean",
   "engines": {
     "vscode": "^1.63.0"


### PR DESCRIPTION
Updated the interpreter logic to check if python3 exists in the PATH before falling back to just python. This should work on more distros that don't supply a python binary anymore and just python3.

Also improves the interpreterPath logic to use the provided path exactly as is for the command.

Fixes: https://github.com/jborean93/vscode-ansibug/issues/3